### PR TITLE
check for gzipped or unzipped HEAD and PHOT files

### DIFF
--- a/create_heatmaps/base.py
+++ b/create_heatmaps/base.py
@@ -242,7 +242,7 @@ class CreateHeatmapsBase(abc.ABC):
                     self._done(sn_name, sn_id)
                     
             # - - - -
-            logging.info(f"job {self.index}: Finsished processing " \
+            logging.info(f"job {self.index}: Finished processing " \
                          f"{n_lc_write} of {n_lc_read} light curves.")
 
             # - - - - - 

--- a/create_heatmaps_job.py
+++ b/create_heatmaps_job.py
@@ -2,6 +2,7 @@
 #
 #
 # Feb 29 2024 RK - begin major refactor (see github issue...)
+# Oct 21 2024 RK - allow gzip or unzipped data (PHOT and HEAD files)
 
 import os, sys, yaml, logging, glob
 import argparse
@@ -143,7 +144,9 @@ def load_lcdata_metadata(config):
             with open(list_file,"rt") as l:
                 meta_list = l.readlines()
                 for meta in meta_list:
-                    meta   = data_path + '/' + meta.rstrip() + '.gz'
+                    meta    = data_path + '/' + meta.rstrip()  
+                    meta_gz = meta + '.gz'  
+                    if os.path.exists(meta_gz):  meta = meta_gz
                     lcdata = meta.replace("HEAD.FITS", "PHOT.FITS")
                     config[key_meta].append(meta)
                     config[key_lcdata].append(lcdata)

--- a/run.py
+++ b/run.py
@@ -92,9 +92,14 @@ def create_snid_select_file(config):
         snid_select_files = []
         for simdir in input_data_paths:
             version = os.path.basename(simdir)
-            dump_file = f"{simdir}/{version}.DUMP.gz"
-            snid_select_files.append(dump_file)
-
+            dump_file    = f"{simdir}/{version}.DUMP"
+            dump_file_gz = f"{dump_file}.gz"
+            if os.path.exists(dump_file):
+                snid_select_files.append(dump_file)
+            elif if os.path.exists(dump_file_gz):
+                snid_select_files.append(dump_file_gz)
+            else: 
+                sys.exit(f"\n cannot select CIDs for sim because there is no DUMP file\n\t {dump_file}")
 
     if is_sim:
         util.load_SIM_README_DOCANA(config)

--- a/scone_utils.py
+++ b/scone_utils.py
@@ -174,7 +174,7 @@ def get_sim_readme_yaml(simdir):
     # Created Apr 2024 by R.Kessler
     # for input sim dir, return contents of readme-yaml file
     version     = os.path.basename(simdir)
-    readme_file = f"{simdir}/{version}.README"
+    readme_file = os.path.expandvars(f"{simdir}/{version}.README")
     contents    = load_config_expandvars(readme_file, [] )
     return contents
 


### PR DESCRIPTION
scone had assumed that data files are gzipped (HEAD and PHOT) and thus failed for unzipped files (e.g., sims run interactively). Fixed to check for both gzip and unzip files.