### PR TITLE
fix subtle bug to allow SNIa to be NONSNIaMODEL0

### DIFF
--- a/create_heatmaps/helpers.py
+++ b/create_heatmaps/helpers.py
@@ -124,8 +124,14 @@ def read_fits(fname, sn_type_id_to_name, survey_from_config, drop_separators=Fal
     if drop_separators:
         lcdata = lcdata[lcdata['MJD'] != -777.000]
 
-    KEY_SIM_GENTYPE = 'SIM_GENTYPE'
+    KEY_SIM_GENTYPE_LIST = [ 'SIM_GENTYPE', 'SIM_TYPE_INDEX' ]
+    KEY_SIM_GENTYPE      = 'xxx'
     KEY_SNTYPE      = 'SNTYPE'   # always there for real data
+
+    for key in KEY_SIM_GENTYPE_LIST:  # Aug 22 2025 : check legacy SIM_TYPE_INDEX
+        if key in df_header.columns:
+            KEY_SIM_GENTYPE = key
+
     is_sim = KEY_SIM_GENTYPE in df_header.columns
 
     head_col_list = ["SNID", "PEAKMJD", "REDSHIFT_FINAL", "REDSHIFT_FINAL_ERR", "MWEBV"]

--- a/run.py
+++ b/run.py
@@ -205,7 +205,7 @@ def create_snid_select_file(config):
     snid_hdf5_file = f"{outdir_heatmaps}/{HEATMAPS_SNID_SELECT_FILE}"
     config['snid_hdf5_file'] = snid_hdf5_file
 
-    logging.info(f"Write {n_select} selected SNIDs to {snid_hdf5_file}")
+    logging.info(f"Prepare to write {n_select} selected SNIDs to {snid_hdf5_file}")
     f = h5py.File(snid_hdf5_file, "w")
 
     # write prescale list [Ia,nonIa] first
@@ -216,7 +216,9 @@ def create_snid_select_file(config):
     else:
         # sim
         for simtag in SIMTAG_LIST :
-            f.create_dataset("ids_" + simtag, data=snid_list_dict[simtag], dtype=np.int32)
+            snid_list = snid_list_dict[simtag]
+            logging.info(f"\t write {len(snid_list)} SNIDs for {simtag}")
+            f.create_dataset("ids_" + simtag, data=snid_list, dtype=np.int32)
 
     f.close()
 


### PR DESCRIPTION
fix subtle bug that required SNIaMODEL name for prefix, and hence didn't work for ELASTICC sims where each model was generated separately as NONIaMODEL0. Also added several more logging.info lines to see more clearly what is read and used form hdf5 file.