### PR TITLE
Rick

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,10 +8,11 @@
 # "scone" task refers to either train or predict mode.
 # "heatmaps" task is the same for train or predict mode.
 #
-# Aug 26 2025 RK - if there are multiple snid_select_files (i.e., Ia and CC),
-# check that VERSION_PHOTOMETRY key in each select_file is a valie sim-version;
-# drop extra snid_select_files to avoid false duplicates.
-#
+# Aug 26 2025 RK -
+#    if there are multiple snid_select_files (i.e., Ia and CC),
+#    check that VERSION_PHOTOMETRY key in each select_file is a valid sim-version;
+#    skip invalid snid_select_files to avoid false duplicates.
+#    See new method use_select_file(...)
 
 import os, sys, yaml, shutil, gzip
 import argparse, subprocess


### PR DESCRIPTION
add logic to drop uncessary snid_select_files. Initial motivation is that BiasCor_IA and CC are done separately, but each has both LCFIT-tables in the SNID_SELECT_FILE list. New logic keeps the relevant SNID_SELECT_FILE(s).