### PR TITLE
read ZP_FLUXCAL from global header instead of hardcoded 27.5

### DIFF
--- a/create_heatmaps/base.py
+++ b/create_heatmaps/base.py
@@ -83,7 +83,7 @@ class CreateHeatmapsBase(abc.ABC):
                 logging.info(" file has already been processed, exiting")
                 sys.exit(0)
                 
-        self.metadata, self.lcdata, survey = \
+        self.metadata, self.lcdata, survey, self.zp_fluxcal = \
                 read_fits(self.lcdata_path, self.sn_type_id_to_name, self.survey)
 
         n_lcdata = len(self.lcdata)

--- a/create_heatmaps/heatmaps_types.py
+++ b/create_heatmaps/heatmaps_types.py
@@ -194,7 +194,7 @@ class MagById(CreateHeatmapsBase):
                 if len(sn_lcdata_r) == 0:
                     continue
                 last_r_flux = sn_lcdata_r['flux'][-1]
-                last_r_mag = 27.5 - 2.5*np.log10(last_r_flux)
+                last_r_mag = self.zp_fluxcal - 2.5*np.log10(last_r_flux)
                 if last_r_mag <= 20:
                     mag_by_id[int(mjdmax)].append(int(sn_id))
 

--- a/create_heatmaps/helpers.py
+++ b/create_heatmaps/helpers.py
@@ -114,6 +114,10 @@ def read_fits(fname_phot, sn_type_id_to_name, survey_from_config, drop_separator
     # load header
     metadata_hdu = fits.open(fname_head)
     survey = survey_from_config if survey_from_config else metadata_hdu[0].header["SURVEY"]
+    ZP_FLUXCAL_DEFAULT = 27.5
+    zp_fluxcal = metadata_hdu[0].header.get("ZP_FLUXCAL", ZP_FLUXCAL_DEFAULT)
+    if zp_fluxcal == ZP_FLUXCAL_DEFAULT:
+        logging.warning(f"ZP_FLUXCAL not found in {os.path.basename(fname_head)} header; using default {ZP_FLUXCAL_DEFAULT}")
 
     header = Table.read(fname_head, format="fits")
     df_header = header.to_pandas()
@@ -181,7 +185,7 @@ def read_fits(fname_phot, sn_type_id_to_name, survey_from_config, drop_separator
     lcdata['passband']  = [ s.strip()[-1:] for s in lcdata['passband']]  
     #sys.exit(f"\n xxx modified lcdata = \n{lcdata}")
 
-    return df_header, lcdata, survey
+    return df_header, lcdata, survey, zp_fluxcal
 
 def build_gp(guess_length_scale, sn_data, bands):
     """This is  all  taken from Avacado -


### PR DESCRIPTION
read ZP_FLUXCAL from global header instead of hardcoded 27.5                                                                                                                                   
                                                                                                                                                                                                                
  MagById.run() now uses self.zp_fluxcal (read from HEAD.FITS primary                                                                                                                                           
  header) for the flux-to-mag conversion. Falls back to 27.5 with a                                                                                                                                             
  warning if ZP_FLUXCAL is absent, preserving backward compatibility.                                                                                                                                           
                                                                                                                                                                                                                
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>